### PR TITLE
Dynamic conf phase 2 st

### DIFF
--- a/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/BasicExternalKafkaClient.java
+++ b/systemtest/src/main/java/io/strimzi/systemtest/kafkaclients/externalClients/BasicExternalKafkaClient.java
@@ -59,6 +59,7 @@ public class BasicExternalKafkaClient extends AbstractKafkaClient implements Aut
     public Future<Integer> sendMessagesPlain(long timeoutMs) {
 
         String clientName = "sender-plain-" + this.clusterName;
+        vertx = Vertx.vertx();
         CompletableFuture<Integer> resultPromise = new CompletableFuture<>();
 
         IntPredicate msgCntPredicate = x -> x == messageCount;


### PR DESCRIPTION
### Type of change

- Enhancement / new feature
- Refactoring

### Description

This PR adding to the `dynamic-conf-phase-2` branch few changes to system test. After this PR https://github.com/strimzi/strimzi-kafka-operator/pull/2802 will be merged it will also resolve issue with the NullPointer of the `vertx`.

### Checklist

- [x] Write tests
- [x] Make sure all tests pass
